### PR TITLE
Fix tactics rating scraping

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -71,7 +71,7 @@ bot.on('/stats', async (msg) => {
       let url = `https://www.chess.com/stats/puzzles/${user.username}`;
       let res = await rp(url);
       let $ = cheerio.load(res);
-      let rating = $('.main-chart-stats-current').text();
+      let rating = $('.rating-block-container').text();
       stats.push(`${user.username} - ${rating} - ${rankingService.getTacticsRating(rating)}`);
     }
 


### PR DESCRIPTION
Chess.com has updated their website and changed the class of the HTML element that holds the tactics rating value. We need to update our code to reflect their change.